### PR TITLE
fix the space at the end of the help tip :tongue:

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ USAGE:
    rizla -onreload="service supervisor restart" main.go or rizla -onreload="cmd /C echo Hello World!" main.go
 VERSION:
    %s
-   `, Name, Description, Version)
+`, Name, Description, Version)
 
 func main() {
 	argsLen := len(os.Args)


### PR DESCRIPTION
before:
![bug](https://user-images.githubusercontent.com/44920018/89714782-cedae400-d9d3-11ea-844f-119c9ed6aed2.png)
after:
![fixed](https://user-images.githubusercontent.com/44920018/89714785-d601f200-d9d3-11ea-9c95-560897d8f2e6.png)
